### PR TITLE
[IMP] date_range. Provide sensible domain for parent_id.

### DIFF
--- a/date_range/views/date_range_view.xml
+++ b/date_range/views/date_range_view.xml
@@ -11,7 +11,10 @@
                 <field name="date_end"/>
                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                 <field name="parent_type_id" invisible="1"/>
-                <field name="parent_id"/>
+                <field
+                    name="parent_id"
+                    options="{'no_create': True}"
+                    />
                 <field name="active"/>
             </tree>
         </field>
@@ -28,7 +31,10 @@
                     <field name="date_end"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                     <field name="parent_type_id" invisible="1"/>
-                    <field name="parent_id"/>
+                    <field
+                        name="parent_id"
+                        options="{'no_create': True}"
+                        />
                     <field name="active"/>
                 </group>
             </form>


### PR DESCRIPTION
Ha Nikos,

Indeed it is not possible to have a domain set directly on the on the parent_id field. This is only possible if all the parts of the domain are constants, not with fields like parent_type_id. Sorry to put you on a wrong footing here.

To compensate I have written the function to set the domain in an on_change handler. Adding in a few extra criteria as well, and for user friendlyness an auto-selection of the parent,