### PR TITLE
[13.0][FIX] server_ftp. Wrong value in demo data.

### DIFF
--- a/server_ftp/demo/server_ftp.xml
+++ b/server_ftp/demo/server_ftp.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
-    <record id="server_ftp_ftp_server" model="server.ftp">
-        <field name="name">FTP</field>
-        <field name="server_type">FTP</field>
+
+    <record id="ftp_server" model="server.ftp">
+        <field name="name">FTP Example Server</field>
+        <field name="server_type">ftp</field>
         <field name="host">ftp.example.com</field>
         <field name="user">user</field>
         <field name="password">password</field>
     </record>
+
 </odoo>

--- a/server_ftp/demo/server_ftp_folder.xml
+++ b/server_ftp/demo/server_ftp_folder.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
+
     <!--- FTP folders-->
-    <record id="server_ftp_push_folder_ftp" model="server.ftp.folder">
+    <record id="ftp_push_folder" model="server.ftp.folder">
         <field name="name">Push folder</field>
         <field name="path">/pull_folder</field>
-        <field name="server_id" ref="server_ftp_ftp_server" />
+        <field name="server_id" ref="ftp_server" />
     </record>
-    <record id="server_ftp_pull_folder_ftp" model="server.ftp.folder">
+
+    <record id="ftp_pull_folder" model="server.ftp.folder">
         <field name="name">Pull folder</field>
         <field name="path">/push_folder</field>
-        <field name="server_id" ref="server_ftp_ftp_server" />
+        <field name="server_id" ref="ftp_server" />
     </record>
+
 </odoo>

--- a/server_ftp/models/server_ftp.py
+++ b/server_ftp/models/server_ftp.py
@@ -81,7 +81,7 @@ class ServerFTP(models.Model):
 
     def _make_server_instance(self):
         """Return server class for selected type."""
-        if self.server_type == "FTP":
+        if self.server_type == "ftp":
             return FTPServer()
         elif self.server_type == "ftptls":
             return FTPTLSServer()


### PR DESCRIPTION
I also shortened the xmlid's somewhat. I found it confusing that except for a dot replaced by an underscore it looked like including the module name.

And changing the code for FTP in ftp was because in general these kind of selection fields have lowercase for the database values.